### PR TITLE
Add md5 for external package downloading

### DIFF
--- a/CMake/externalBoost.cmake
+++ b/CMake/externalBoost.cmake
@@ -4,6 +4,7 @@ ExternalProject_Add(
   Boost
   PREFIX ${CMAKE_CURRENT_SOURCE_DIR}/external/boost
   URL https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.gz
+  URL_MD5 38813f6feb40387dfe90160debd71251
   UPDATE_COMMAND ""
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""

--- a/CMake/externalRapidJSON.cmake
+++ b/CMake/externalRapidJSON.cmake
@@ -4,6 +4,7 @@ ExternalProject_Add(
   RapidJSON
   PREFIX ${CMAKE_CURRENT_SOURCE_DIR}/external/RapidJSON
   URL https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz
+  URL_MD5 badd12c511e081fec6c89c43a7027bce
   UPDATE_COMMAND ""
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cd overlaybd
 mkdir build
 cd build
 cmake ..
-make
+make -j
 sudo make install
 
 # restart tgt service to reload backing-store


### PR DESCRIPTION
Signed-off-by: chenbo <chenbo.chen@alibaba-inc.com>

According to CMake

> Specifying this option is strongly recommended for URL downloads, as it ensures the integrity of the downloaded content. It is also used as a check for a previously downloaded file, allowing connection to the remote location to be avoided altogether if the local directory already has a file from an earlier download that matches the specified hash.

TODO: Add Readme to illustrate how to prepare third-party packages manually, if network got some problems. For instance, behind firewall.