### PR TITLE
fix compile error of missing include string #18

### DIFF
--- a/src/overlaybd/net/curl.cpp
+++ b/src/overlaybd/net/curl.cpp
@@ -14,6 +14,7 @@
    limitations under the License.
 */
 #include <curl/curl.h>
+#include <string>
 
 #include "../alog.h"
 #include "../event-loop.h"


### PR DESCRIPTION
Closes #18 