### PR TITLE
fix some compile error/warning #9

### DIFF
--- a/src/overlaybd/alog.h
+++ b/src/overlaybd/alog.h
@@ -600,8 +600,11 @@ struct LogBuilder {
 };
 
 #define DEFINE_PROLOGUE(level, prolog)                                                             \
-    const static Prologue prolog{(uint64_t) __func__,  (uint64_t)__FILE__, sizeof(__func__) - 1,   \
-                                 sizeof(__FILE__) - 1, __LINE__,           level};
+    const static uint64_t _addr_func = (uint64_t) __func__;                                        \
+    const static size_t _len_func = sizeof(__func__) - 1;                                          \
+    const static Prologue prolog{_addr_func, (uint64_t)__FILE__,                                   \
+                                 _len_func,  sizeof(__FILE__) - 1,                                 \
+                                 __LINE__,   level};
 
 #define PARSE_FMTSTR(S, thesequence)                                                               \
     struct static_string {                                                                         \

--- a/src/overlaybd/fs/lsmt/index.cpp
+++ b/src/overlaybd/fs/lsmt/index.cpp
@@ -166,8 +166,9 @@ public:
 
     void print_info() {
         char msg[256]{};
+        char *cur = msg;
         for (auto it = level_mapping.begin(); it != level_mapping.end(); it++) {
-            sprintf(msg, "%s %zu ", msg, (*it).size());
+            cur += sprintf(cur, " %zu ", (*it).size());
         }
         LOG_INFO("create level index, depth: `, elements # per level {` `}", level_mapping.size(),
                  msg, this->size());

--- a/src/overlaybd/fs/lsmt/index.cpp
+++ b/src/overlaybd/fs/lsmt/index.cpp
@@ -167,7 +167,7 @@ public:
     void print_info() {
         char msg[256]{};
         for (auto it = level_mapping.begin(); it != level_mapping.end(); it++) {
-            sprintf(msg, "%s %lu ", msg, (*it).size());
+            sprintf(msg, "%s %zu ", msg, (*it).size());
         }
         LOG_INFO("create level index, depth: `, elements # per level {` `}", level_mapping.size(),
                  msg, this->size());

--- a/src/overlaybd/utility.h
+++ b/src/overlaybd/utility.h
@@ -211,8 +211,6 @@ public:
     }
 };
 
-#define _unused(x) ((void)(x))
-
 // release resource by RAII
 #define WITH(init_expr) if (init_expr)
 

--- a/src/tools/overlaybd-commit.cpp
+++ b/src/tools/overlaybd-commit.cpp
@@ -20,6 +20,7 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <memory>
+#include <string>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>

--- a/src/tools/overlaybd-create.cpp
+++ b/src/tools/overlaybd-create.cpp
@@ -18,6 +18,7 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <memory>
+#include <string>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>


### PR DESCRIPTION
1) WARNING both gcc9/gcc10
```
[ 27%] Linking CXX static library ../../output/libbase_lib.a
/root/wujiaxu/workspace/cpp/overlaybd/src/overlaybd/fs/lsmt/index.cpp: In member function ‘void LSMT::LevelIndex::print_info()’:
/root/wujiaxu/workspace/cpp/overlaybd/src/overlaybd/fs/lsmt/index.cpp:170:30: warning: ‘%lu’ directive writing between 1 and 20 bytes into a region of size between 0 and 255 [-Wformat-overflow=]
  170 |             sprintf(msg, "%s %lu ", msg, (*it).size());
      |                              ^~~
/root/wujiaxu/workspace/cpp/overlaybd/src/overlaybd/fs/lsmt/index.cpp:170:20: note: ‘sprintf’ output between 4 and 278 bytes into a destination of size 256
  170 |             sprintf(msg, "%s %lu ", msg, (*it).size());
      |             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

2) ERROR only gcc10
```
[ 88%] Building CXX object src/tools/CMakeFiles/overlaybd-info.dir/overlaybd-info.cpp.o
/root/wujiaxu/workspace/cpp/overlaybd/src/tools/overlaybd-commit.cpp:58:8: error: aggregate ‘std::string commit_msg’ has incomplete type and cannot be defined
   58 | string commit_msg;
      |        ^~~~~~~~~~
/root/wujiaxu/workspace/cpp/overlaybd/src/tools/overlaybd-commit.cpp:59:8: error: aggregate ‘std::string parent_uuid’ has incomplete type and cannot be defined
   59 | string parent_uuid;
      |        ^~~~~~~~~~~
/root/wujiaxu/workspace/cpp/overlaybd/src/tools/overlaybd-commit.cpp: In function ‘void parse_args(int, char**)’:
/root/wujiaxu/workspace/cpp/overlaybd/src/tools/overlaybd-commit.cpp:80:44: error: invalid use of incomplete type ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}
   80 |                 parent_uuid = string(optarg);
      |                                            ^
In file included from /usr/include/c++/10/iosfwd:39,
                 from /usr/include/c++/10/memory:74,
                 from /root/wujiaxu/workspace/cpp/overlaybd/src/tools/overlaybd-commit.cpp:22:
/usr/include/c++/10/bits/stringfwd.h:74:11: note: declaration of ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}
   74 |     class basic_string;
      |           ^~~~~~~~~~~~
/root/wujiaxu/workspace/cpp/overlaybd/src/tools/overlaybd-create.cpp:57:8: error: aggregate ‘std::string parent_uuid’ has incomplete type and cannot be defined
   57 | string parent_uuid;
      |        ^~~~~~~~~~~
make[2]: *** [src/tools/CMakeFiles/overlaybd-commit.dir/build.make:63: src/tools/CMakeFiles/overlaybd-commit.dir/overlaybd-commit.cpp.o] Error 1
```

3) ERROR both gcc9/gcc10
Closes #9 