### PR TITLE
Fix Prefetcher segment fault in destructor

### DIFF
--- a/src/prefetch.cpp
+++ b/src/prefetch.cpp
@@ -76,7 +76,6 @@ public:
 
         // Reload if going to replay
         if (m_mode == Mode::Replay) {
-            m_replay_threads.resize(REPLAY_CONCURRENCY);
             reload(file_size);
         }
     }
@@ -126,7 +125,8 @@ public:
         LOG_INFO("Prefetch: Replay ` records from ` layers", m_replay_queue.size(), m_src_files.size());
         for (int i = 0; i < REPLAY_CONCURRENCY; ++i) {
             auto th = photon::thread_create11(&PrefetcherImpl::replay_worker_thread, this);
-            m_replay_threads[i] = photon::thread_enable_join(th);
+            auto join_handle = photon::thread_enable_join(th);
+            m_replay_threads.push_back(join_handle);
         }
     }
 


### PR DESCRIPTION
When the Prefetcher's destructor is called before `replay`, the `thread_enable_join` will be passed with a nullptr.
So remove the vecotr initialization in constrctor.

Signed-off-by: Bob Chen <beef9999@qq.com>