### PR TITLE
Fix curl headermap setting value during redirection

### DIFF
--- a/src/overlaybd/net/curl.h
+++ b/src/overlaybd/net/curl.h
@@ -74,7 +74,8 @@ public:
         auto pos = st.find_first_of(':');
         if (pos != estring::npos) {
             // somehow http header is defined case insensitive
-            this->emplace(str_lower(st.substr(0, pos).trim()), st.substr(pos + 1).trim());
+            (*this)[str_lower(st.substr(0, pos).trim())] =
+                st.substr(pos + 1).trim();
         }
         return n;
     }


### PR DESCRIPTION
HeaderMap should able to set each key multiple times,
so redirected response header will keep final rewritten headers,
such as "Content-Type", "Content-Length", etc.

Signed-off-by: Du Rui <coldwings@me.com>